### PR TITLE
Feature/copy update

### DIFF
--- a/pir_frontend/templates/index.html
+++ b/pir_frontend/templates/index.html
@@ -123,7 +123,7 @@ If you would like to receive further information about setting up your business 
     {% else %}
             <p>
         {% blocktrans %}
-          Thank You. Your personalised Investment Report has been emailed to {{ email }}
+          Thank You. Your Perfect Fit Prospectus has been emailed to {{ email }}
         {% endblocktrans %}
             </p>
     {% endif %}

--- a/pir_frontend/templates/index.html
+++ b/pir_frontend/templates/index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load i18n static %}
 
-{% block head_title %}{% trans "Personalised Investment Report:" %}{% endblock %}
+{% block head_title %}{% trans "Perfect Fit Prospectus" %}{% endblock %}
 
 
 {% block body_header %}


### PR DESCRIPTION
The confirmation page copy should be updated – replace ‘Personalised Investment Report’ with ‘Perfect Fit Prospectus’
The meta title on the form page should be ‘Perfect Fit Prospectus’
